### PR TITLE
Typo for Angel Bunny fixed

### DIFF
--- a/assets/minecraft/lang/eq_eq.json
+++ b/assets/minecraft/lang/eq_eq.json
@@ -140,7 +140,7 @@
   "entity.minecraft.player": "Pony",
   "entity.minecraft.potion": "Cider",
   "entity.minecraft.chicken": "Scootaloo",
-  "entity.minecraft.rabbit": "Engel Bunny",
+  "entity.minecraft.rabbit": "Angel Bunny",
   "entity.minecraft.zombie": "Zompony",
   "entity.minecraft.zombie_pigman": "Zompig",
   "entity.minecraft.zombie_villager": "Zompony Villager",


### PR DESCRIPTION
line 143: there was a typo where "Angel Bunny" was "Engel Bunny"